### PR TITLE
Remove Facebook link from footer

### DIFF
--- a/kiwi.php
+++ b/kiwi.php
@@ -201,7 +201,6 @@ class KiwiTemplate extends BaseTemplate {
             <div class="nav-group">
                 <h4>Social Media</h4>
                 <ul class="nav-social-media">
-                    <li><a href="https://www.facebook.com/hackerspace.bamberg">Facebook</a></li>
                     <li><a href="https://plus.google.com/u/0/116003874054937500169">google+</a></li>
                     <li><a href="https://twitter.com/b4ckspace">twitter</a></li>
                     <li><a href="https://vimeo.com/backspace">vimeo</a></li>


### PR DESCRIPTION
Based on plenum discussion in January and February 2020, Facebook should no longer be used. As a consequence all links should be removed.