### PR TITLE
Replace link to contact page

### DIFF
--- a/kiwi.php
+++ b/kiwi.php
@@ -172,7 +172,7 @@ class KiwiTemplate extends BaseTemplate {
                         <li class="last leaf"><a href="<?php echo $this->getPageURL('Verein:Preisliste'); ?>">Preisliste</a>
                     </ul>
                 </li>
-                <li class="last leaf"><a href="<?php echo $this->getPageURL('Spezial:Kontakt'); ?>">Kontakt</a></li>
+                <li class="last leaf"><a href="<?php echo $this->getPageURL('Kontakt'); ?>">Kontakt</a></li>
             </ul>
         </div>
 


### PR DESCRIPTION
The current contact form does not work therefore point the contact navigation link to a page with more helpful information.