### PR TITLE
Remove email fragment from footer

### DIFF
--- a/kiwi.php
+++ b/kiwi.php
@@ -240,7 +240,6 @@ class KiwiTemplate extends BaseTemplate {
 
                 <div class="nav-phone">
                     Tel: (0951) 18 50 51 45<br>
-                    Mail: vorstand@
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The footer shows the local part of the email (probably for reducing spam). Only few people will come up with the idea to append the domain of the page to the local part. To other people this will appear as error. To reduce confusion, this is removed as the contact page will provide more accessible information.